### PR TITLE
Fixed GCO naming issue according to the following description.

### DIFF
--- a/step2_segm_vote_gmm.py
+++ b/step2_segm_vote_gmm.py
@@ -103,8 +103,8 @@ def main(unwrap_dir, segm_out_file, gmm_out_file):
     edges_to = np.r_[v_edges_to, h_edges_to, s_edges_to]
     edges_w = np.r_[np.ones_like(v_edges_from), np.ones_like(h_edges_from), np.ones_like(s_edges_from)]
 
-    gc = gco.gco()
-    gc.createGeneralGraph(1000 ** 2, pairwise.shape[0], True)
+    gc = gco.GCO()
+    gc.create_general_graph(1000 ** 2, pairwise.shape[0], True)
     gc.set_data_cost(unaries.reshape(1000 ** 2, pairwise.shape[0]))
 
     gc.set_all_neighbors(edges_from, edges_to, edges_w)

--- a/stitch/texels_fusion.py
+++ b/stitch/texels_fusion.py
@@ -43,8 +43,8 @@ class Stitcher:
 
     def stich(self, im0, im1, unaries0, unaries1, labels0, labels1, pairwise_mask, segmentation):
 
-        gc = gco.gco()
-        gc.createGeneralGraph(self.tex_res ** 2, 2, True)
+        gc = gco.GCO()
+        gc.create_general_graph(self.tex_res ** 2, 2, True)
         gc.set_data_cost(np.dstack((unaries0, unaries1)).reshape(-1, 2))
 
         edges_w = self._rgb_grad(im0, im1, labels0, labels1, pairwise_mask, segmentation)


### PR DESCRIPTION
I am experiencing error in step2_segm_vote_gmm.py:
File "step2_segm_vote_gmm.py", line 107, in main gc = gco.gco()

The problem is resolved by changing gco.gco() to gco.GCO().

Furthermore, on the next line, there is gc.createGeneralGraph(1000 ** 2, pairwise.shape[0], True), but should be gc.create_general_graph(1000 ** 2, pairwise.shape[0], True).

There are probably more places with the wrong naming of the GCO library. Shall I create a pull request with a fix?

I am on MacOS 10.15.7, homebrew python2.7, GCO version 3.0.2 (master, commit: 1203f5a7c0e458de7dc7191f7d5f89b9ce985e7a).